### PR TITLE
Create `TagList` view for managing tags

### DIFF
--- a/extensions/toggl-track/src/api/index.ts
+++ b/extensions/toggl-track/src/api/index.ts
@@ -3,6 +3,6 @@ export { getMyOrganizations, type Organization } from "./organizations";
 export { getMyWorkspaces, type Workspace } from "./workspaces";
 export { getMyProjects, type Project } from "./projects";
 export { getMyClients, type Client } from "./clients";
-export { getMyTags, type Tag } from "./tags";
+export { getMyTags, createTag, updateTag, deleteTag, type Tag } from "./tags";
 export { getMyTasks, type Task } from "./tasks";
 export { getMyTimeEntries, createTimeEntry, stopTimeEntry, getRunningTimeEntry, type TimeEntry } from "./timeEntries";

--- a/extensions/toggl-track/src/api/tags.ts
+++ b/extensions/toggl-track/src/api/tags.ts
@@ -1,7 +1,19 @@
-import { get } from "./togglClient";
+import { get, post, put, remove } from "./togglClient";
 
 export function getMyTags() {
   return get<Tag[]>("/me/tags");
+}
+
+export function createTag(workspaceId: number, name: string) {
+  return post<Tag[]>(`/workspaces/${workspaceId}/tags`, { workspace_id: workspaceId, name });
+}
+
+export function updateTag(workspaceId: number, tagId: number, name: string) {
+  return put<Tag[]>(`/workspaces/${workspaceId}/tags/${tagId}`, { workspace_id: workspaceId, name });
+}
+
+export function deleteTag(workspaceId: number, tagId: number) {
+  return remove(`/workspaces/${workspaceId}/tags/${tagId}`);
 }
 
 // https://developers.track.toggl.com/docs/api/tags#response

--- a/extensions/toggl-track/src/components/TagForm.tsx
+++ b/extensions/toggl-track/src/components/TagForm.tsx
@@ -1,0 +1,46 @@
+import { ActionPanel, Form, Action, showToast, Toast, useNavigation } from "@raycast/api";
+import { Workspace, Tag, updateTag, createTag } from "../api";
+
+interface TagFormProps {
+  tag?: Tag;
+  workspace: Workspace;
+  revalidateTags: () => void;
+}
+
+export default function TagForm({ workspace, tag, revalidateTags }: TagFormProps) {
+  const { pop } = useNavigation();
+
+  async function handleSubmit({ name }: { name: string }) {
+    const toast = await showToast(Toast.Style.Animated, (tag ? "Updating" : "Creating") + " Tag");
+    try {
+      if (tag) await updateTag(tag.workspace_id, tag.id, name);
+      else if (workspace) {
+        await createTag(workspace.id, name);
+      } else {
+        throw new Error('TagForm must be passed either "workspaces" or "tag"');
+      }
+      toast.style = Toast.Style.Success;
+      toast.title = toast.title.replace("ing", "ed");
+      revalidateTags();
+      pop();
+    } catch (error) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Couldn't " + toast.title.replace("ing", "e");
+      if (error instanceof Error) {
+        toast.message = error.message;
+      }
+    }
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title={tag ? "Rename" : "Create" + " Tag"} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="name" title="Name" defaultValue={tag?.name} />
+    </Form>
+  );
+}

--- a/extensions/toggl-track/src/components/TagList.tsx
+++ b/extensions/toggl-track/src/components/TagList.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import { List, ActionPanel, Action, Icon, confirmAlert, showToast, Toast } from "@raycast/api";
+import { useTags } from "../hooks";
+import { Workspace, Tag, deleteTag } from "../api";
+import TagForm from "./TagForm";
+
+interface TagListProps {
+  workspace: Workspace;
+  isLoading: boolean;
+}
+
+export default function TagList({ workspace, isLoading }: TagListProps) {
+  const { tags, isLoadingTags, revalidateTags } = useTags();
+
+  const filteredTags = useMemo(() => tags.filter((tag) => tag.workspace_id === workspace.id), [tags]);
+
+  const canModifyTag = useMemo(
+    () => !workspace.only_admins_may_create_tags || workspace.role == "admin" || workspace.role == "projectlead",
+    [workspace],
+  );
+
+  async function handleTagDelete(tag: Tag) {
+    if (
+      await confirmAlert({
+        title: "Are You Sure?",
+        message: "Deleting this tag will permanently remove it from all time entries.",
+      })
+    ) {
+      const toast = await showToast({ title: "Deleting Tag", style: Toast.Style.Animated });
+      try {
+        await deleteTag(tag.workspace_id, tag.id);
+        revalidateTags();
+        toast.style = Toast.Style.Success;
+        toast.title = "Tag deleted";
+      } catch (error) {
+        toast.style = Toast.Style.Failure;
+        toast.title = "Couldn't deleted tag";
+        if (error instanceof Error) toast.message = error.message;
+      }
+    }
+  }
+
+  return (
+    <List isLoading={isLoading || isLoadingTags}>
+      {filteredTags.length == 0 && <List.EmptyView title="No Tags Found" />}
+      {filteredTags.map((tag) => (
+        <List.Item
+          title={tag.name}
+          key={tag.id}
+          actions={
+            canModifyTag ? (
+              <ActionPanel>
+                <ActionPanel.Section>
+                  <Action.Push
+                    title="Rename Tag"
+                    icon={Icon.Pencil}
+                    shortcut={{ key: "e", modifiers: ["cmd", "shift"] }}
+                    target={<TagForm {...{ tag, workspace, revalidateTags }} />}
+                  />
+                  <Action
+                    title="Delete Tag"
+                    icon={Icon.Trash}
+                    shortcut={{ key: "x", modifiers: ["ctrl"] }}
+                    style={Action.Style.Destructive}
+                    onAction={() => handleTagDelete(tag)}
+                  />
+                </ActionPanel.Section>
+                <Action.Push
+                  title="Create New Tag"
+                  icon={Icon.Plus}
+                  shortcut={{ key: "n", modifiers: ["cmd", "shift"] }}
+                  target={<TagForm {...{ workspace, revalidateTags }} />}
+                />
+              </ActionPanel>
+            ) : undefined
+          }
+        />
+      ))}
+    </List>
+  );
+}

--- a/extensions/toggl-track/src/manageWorkspaces.tsx
+++ b/extensions/toggl-track/src/manageWorkspaces.tsx
@@ -3,6 +3,7 @@ import { List, Image, ActionPanel, Action } from "@raycast/api";
 import { ExtensionContextProvider } from "./context/ExtensionContext";
 import { useOrganizations, useWorkspaces } from "./hooks";
 import { Workspace } from "./api";
+import TagList from "./components/TagList";
 
 function ManageWorkspaces() {
   const { organizations, isLoadingOrganizations } = useOrganizations();
@@ -78,6 +79,15 @@ function ManageWorkspaces() {
                 <Action
                   title={`${isShoingDetails ? "Hide" : "Show"} Details`}
                   onAction={() => setIsShoingDetails((value) => !value)}
+                />
+                <Action.Push
+                  title="Manage Tags"
+                  shortcut={{ key: "t", modifiers: ["cmd", "shift"] }}
+                  target={
+                    <ExtensionContextProvider>
+                      <TagList workspace={workspace} isLoading={isLoadingWorkspaces} />
+                    </ExtensionContextProvider>
+                  }
                 />
               </ActionPanel>
             }


### PR DESCRIPTION
This will be the view for the "Manage Tags" action in bkeys818/raycast-extensions#8.

## `TagList` View

`List` of a workspace's tags

### List Item

- Tag Name

### Actions

> When not `only_admins_may_create_tags` or role is `admin | projectlead`

- Rename Tag
- Delete Tag
- Create New Tag