### PR TITLE
[Notion] Refactor `PagePropertyField`

### DIFF
--- a/extensions/notion/src/components/forms/CreatePageForm.tsx
+++ b/extensions/notion/src/components/forms/CreatePageForm.tsx
@@ -28,7 +28,7 @@ import { handleOnOpenPage } from "../../utils/openPage";
 import { ActionSetVisibleProperties } from "../actions";
 import { ActionSetOrderProperties } from "../actions";
 
-import { createConvertToFieldFunc, FieldProps } from "./PagePropertyField";
+import { PagePropertyField } from "./PagePropertyField";
 
 export type CreatePageFormValues = {
   database: string | undefined;
@@ -174,18 +174,6 @@ export function CreatePageForm({ mutate, launchContext, defaults }: CreatePageFo
     });
   }
 
-  function itemPropsFor<T extends DatabaseProperty["type"]>(property: DatabaseProperty) {
-    const id = createPropertyId(property);
-    return {
-      ...(itemProps[id] as FieldProps<T>),
-      title: property.name,
-      key: id,
-      id,
-    };
-  }
-
-  const convertToField = createConvertToFieldFunc(itemPropsFor, relationPages, users);
-
   const renderSubmitAction = (type: "main" | "second") => {
     const shortcut: Keyboard.Shortcut | undefined =
       type === "second" ? { modifiers: ["cmd", "shift"], key: "enter" } : undefined;
@@ -276,7 +264,22 @@ export function CreatePageForm({ mutate, launchContext, defaults }: CreatePageFo
         </>
       )}
 
-      {databaseProperties?.filter(filterProperties).sort(sortProperties).map(convertToField)}
+      {databaseProperties
+        ?.filter(filterProperties)
+        .sort(sortProperties)
+        .map((dp) => {
+          const id = createPropertyId(dp);
+          return (
+            <PagePropertyField
+              type={dp.type}
+              databaseProperty={dp}
+              itemProps={itemProps[id]}
+              relationPages={relationPages}
+              users={users}
+              key={id}
+            />
+          );
+        })}
       <Form.Separator />
       <Form.TextArea
         {...itemProps["content"]}

--- a/extensions/notion/src/components/forms/PagePropertyField.tsx
+++ b/extensions/notion/src/components/forms/PagePropertyField.tsx
@@ -1,57 +1,91 @@
 import { Form, Icon, Image } from "@raycast/api";
 import type { useForm } from "@raycast/utils";
 
-import { notionColorToTintColor, getPageIcon, Page, DatabaseProperty, User, PropertyConfig } from "../../utils/notion";
+import {
+  notionColorToTintColor,
+  getPageIcon,
+  Page,
+  DatabaseProperty,
+  User,
+  PropertyConfig,
+  ReadablePropertyType,
+  FormValueForDatabaseProperty,
+} from "../../utils/notion";
 
-export function createConvertToFieldFunc(
-  itemPropsFor: GetFieldPropsFunc,
-  relationPages: Record<string, Page[]> | undefined,
-  users: User[],
-) {
-  return (property: DatabaseProperty) => {
-    let placeholder = property.type.replace(/_/g, " ");
-    placeholder = placeholder.charAt(0).toUpperCase() + placeholder.slice(1);
-
-    switch (property.type) {
-      case "date":
-        return <Form.DatePicker {...itemPropsFor<typeof property.type>(property)} />;
-      case "checkbox":
-        return <Form.Checkbox {...itemPropsFor<typeof property.type>(property)} label={placeholder} />;
-      case "select":
-      case "status":
-        return (
-          <Form.Dropdown {...itemPropsFor<typeof property.type>(property)}>
-            {property.config.options.map(createMapOptionsFunc(Form.Dropdown.Item))}
-          </Form.Dropdown>
-        );
-      case "multi_select":
-      case "relation":
-      case "people": {
-        let options: ItemOption[] | Page[] | User[] | undefined;
-        if (property.type == "multi_select") options = property.config.options;
-        else if (property.type == "people") options = users;
-        else if (relationPages && property.type == "relation") {
-          const relationId = property.config.database_id;
-          if (relationId) options = relationPages[relationId];
-        }
-        return (
-          <Form.TagPicker placeholder={placeholder} {...itemPropsFor<typeof property.type>(property)}>
-            {options?.map(createMapOptionsFunc(Form.TagPicker.Item))}
-          </Form.TagPicker>
-        );
-      }
-      case "formula":
-        return null;
-      default:
-        return (
-          <Form.TextField
-            info="Supports a single line of inline Markdown"
-            placeholder={placeholder}
-            {...itemPropsFor<typeof property.type>(property)}
-          />
-        );
-    }
+// @ts-expect-error - Overload doesn't match, but is the function signature we want to be visisble.
+export function PagePropertyField(props: {
+  type: ReadablePropertyType;
+  databaseProperty: DatabaseProperty;
+  itemProps: ReturnType<typeof useForm>["itemProps"][string];
+  relationPages: Record<string, Page[]> | undefined;
+  users: User[];
+}): JSX.Element;
+export function PagePropertyField({
+  type,
+  databaseProperty,
+  itemProps,
+  relationPages,
+  users,
+}: {
+  [DP in DatabaseProperty as DP["type"]]: {
+    type: DP["type"];
+    databaseProperty: DP;
+    itemProps: Form.ItemProps<FormValueForDatabaseProperty<DP["type"]>>;
+    relationPages: Record<string, Page[]> | undefined;
+    users: User[];
   };
+}[ReadablePropertyType]) {
+  // Note: `key` shouldn't be passed to a react component with the spread opperator.
+  const sharedProps = { title: databaseProperty.name, placeholder: createPlaceholder(databaseProperty) };
+  switch (type) {
+    case "date":
+      return <Form.DatePicker {...itemProps} {...sharedProps} key={itemProps.id} />;
+    case "checkbox":
+      return <Form.Checkbox {...itemProps} {...sharedProps} key={itemProps.id} label={sharedProps.placeholder} />;
+    case "select":
+    case "status":
+      return (
+        <Form.Dropdown {...itemProps} {...sharedProps} key={itemProps.id}>
+          {databaseProperty.config.options.map(createMapOptionsFunc(Form.Dropdown.Item))}
+        </Form.Dropdown>
+      );
+    case "multi_select":
+    case "relation":
+    case "people": {
+      let options: ItemOption[] | Page[] | User[] | undefined;
+      if (databaseProperty.type == "multi_select") options = databaseProperty.config.options;
+      else if (databaseProperty.type == "people") options = users;
+      else if (relationPages && databaseProperty.type == "relation") {
+        const relationId = databaseProperty.config.database_id;
+        if (relationId) options = relationPages[relationId];
+      }
+      return (
+        <Form.TagPicker {...itemProps} {...sharedProps} key={itemProps.id}>
+          {options?.map(createMapOptionsFunc(Form.TagPicker.Item))}
+        </Form.TagPicker>
+      );
+    }
+    case "formula":
+      return null;
+    case "title":
+      return (
+        <Form.TextField
+          {...itemProps}
+          {...sharedProps}
+          key={itemProps.id}
+          info="Supports a single line of inline Markdown"
+        />
+      );
+    default:
+      return (
+        <Form.TextField
+          {...itemProps}
+          {...sharedProps}
+          key={itemProps.id}
+          info="Supports a single line of inline Markdown"
+        />
+      );
+  }
 }
 
 type ItemOption = PropertyConfig<"select">["options"][number];
@@ -74,18 +108,8 @@ function createMapOptionsFunc(Tag: typeof Form.Dropdown.Item | typeof Form.TagPi
   };
 }
 
-export type GetFieldPropsFunc = <T extends DatabaseProperty["type"]>(property: DatabaseProperty) => FieldProps<T>;
-
-export type FieldProps<T extends DatabaseProperty["type"]> = ReturnType<
-  typeof useForm<{
-    [k: string]: T extends "date"
-      ? Date | null
-      : T extends "checkbox"
-        ? boolean
-        : T extends "multi_select" | "relation" | "people"
-          ? string[]
-          : T extends "formula"
-            ? null
-            : string;
-  }>
->["itemProps"][string];
+function createPlaceholder(property: DatabaseProperty) {
+  let placeholder = property.type.replace(/_/g, " ");
+  placeholder = placeholder.charAt(0).toUpperCase() + placeholder.slice(1);
+  return placeholder;
+}

--- a/extensions/notion/src/utils/notion/page/property.ts
+++ b/extensions/notion/src/utils/notion/page/property.ts
@@ -50,7 +50,7 @@ export function formValueToPropertyValue(
 }
 
 // prettier-ignore
-type FormValueForDatabaseProperty<T extends ReadablePropertyType> =
+export type FormValueForDatabaseProperty<T extends ReadablePropertyType> =
         T extends "date" ? Date | null
       : T extends "checkbox" ? boolean
       : T extends "multi_select" | "relation" | "people" ? string[]


### PR DESCRIPTION
## Description

By implementing a function overload and a few other TypeScript tricks, `PagePropertyField` has been refactored. It's now...
- Easier to read (especially from the outside)
- Handles types better
- Will be easier to close raycast/extensions#12751