### PR TITLE
Convert view configuration from LocalStorage to Cache

### DIFF
--- a/extensions/notion/src/components/DatabaseList.tsx
+++ b/extensions/notion/src/components/DatabaseList.tsx
@@ -2,7 +2,7 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useEffect, useState } from "react";
 
-import { useDatabaseProperties, useDatabasesView } from "../hooks";
+import { useDatabaseProperties } from "../hooks";
 import { queryDatabase, getPageName, Page, User } from "../utils/notion";
 
 import { DatabaseView } from "./DatabaseView";
@@ -30,13 +30,11 @@ export function DatabaseList({ databasePage, setRecentPage, removeRecentPage, us
     { keepPreviousData: true },
   );
   const { data: databaseProperties, isLoading: isLoadingDatabaseProperties } = useDatabaseProperties(databaseId);
-  const { data: databaseView, isLoading: isLoadingDatabaseViews, setDatabaseView } = useDatabasesView(databaseId);
-
   useEffect(() => {
     setRecentPage(databasePage);
   }, [databaseId]);
 
-  if (isLoadingDatabaseProperties || isLoadingDatabaseViews) {
+  if (isLoadingDatabaseProperties) {
     return <List isLoading />;
   }
 
@@ -62,8 +60,6 @@ export function DatabaseList({ databasePage, setRecentPage, removeRecentPage, us
         databaseId={databaseId}
         databasePages={databasePages ?? []}
         databaseProperties={databaseProperties}
-        databaseView={databaseView}
-        setDatabaseView={setDatabaseView}
         sort={sort}
         mutate={mutate}
         setRecentPage={setRecentPage}

--- a/extensions/notion/src/components/DatabaseList.tsx
+++ b/extensions/notion/src/components/DatabaseList.tsx
@@ -27,6 +27,7 @@ export function DatabaseList({ databasePage, setRecentPage, removeRecentPage, us
   } = useCachedPromise(
     (databaseId, searchText, sort) => queryDatabase(databaseId, searchText, sort),
     [databaseId, searchText, sort],
+    { keepPreviousData: true },
   );
   const { data: databaseProperties, isLoading: isLoadingDatabaseProperties } = useDatabaseProperties(databaseId);
   const { data: databaseView, isLoading: isLoadingDatabaseViews, setDatabaseView } = useDatabasesView(databaseId);

--- a/extensions/notion/src/components/DatabaseList.tsx
+++ b/extensions/notion/src/components/DatabaseList.tsx
@@ -39,15 +39,11 @@ export function DatabaseList({ databasePage, setRecentPage, removeRecentPage, us
     return <List isLoading />;
   }
 
-  const navigationTitle = databaseView?.name
-    ? (databasePage.icon_emoji ? databasePage.icon_emoji + " " : "") + databaseView.name
-    : databaseName;
-
   return (
     <List
       isLoading={isLoading}
       searchBarPlaceholder="Filter pages"
-      navigationTitle={navigationTitle}
+      navigationTitle={databaseName}
       onSearchTextChange={setSearchText}
       searchBarAccessory={
         <List.Dropdown

--- a/extensions/notion/src/components/DatabaseView.tsx
+++ b/extensions/notion/src/components/DatabaseView.tsx
@@ -2,7 +2,6 @@ import { List, Image } from "@raycast/api";
 
 import { useKanbanViewConfig } from "../hooks";
 import { notionColorToTintColor, isType, Page, DatabaseProperty, PropertyConfig, User } from "../utils/notion";
-import type { DatabaseView } from "../utils/types";
 
 import { PageListItem } from "./PageListItem";
 import { ActionEditPageProperty } from "./actions";
@@ -11,8 +10,6 @@ type DatabaseViewProps = {
   databaseId: string;
   databasePages: Page[];
   databaseProperties: DatabaseProperty[];
-  databaseView?: DatabaseView;
-  setDatabaseView?: (view: DatabaseView) => Promise<void>;
   setRecentPage: (page: Page) => Promise<void>;
   removeRecentPage: (id: string) => Promise<void>;
   mutate: () => Promise<void>;
@@ -21,17 +18,7 @@ type DatabaseViewProps = {
 };
 
 export function DatabaseView(props: DatabaseViewProps) {
-  const {
-    databaseId,
-    databasePages,
-    databaseProperties,
-    databaseView,
-    setDatabaseView,
-    mutate,
-    setRecentPage,
-    removeRecentPage,
-    users,
-  } = props;
+  const { databaseId, databasePages, databaseProperties, mutate, setRecentPage, removeRecentPage, users } = props;
 
   const { kanbanConfig } = useKanbanViewConfig(databaseId);
   const statusProperty = kanbanConfig?.property_id
@@ -52,8 +39,6 @@ export function DatabaseView(props: DatabaseViewProps) {
             page={p}
             mutate={mutate}
             databaseProperties={databaseProperties}
-            databaseView={databaseView}
-            setDatabaseView={setDatabaseView}
             setRecentPage={setRecentPage}
             removeRecentPage={removeRecentPage}
             users={users}
@@ -191,10 +176,8 @@ export function DatabaseView(props: DatabaseViewProps) {
                 mutate={mutate}
               />,
             ]}
-            databaseView={databaseView}
             isKanban={kanbanConfig.active}
             databaseProperties={databaseProperties}
-            setDatabaseView={setDatabaseView}
             mutate={mutate}
           />
         ))}

--- a/extensions/notion/src/components/DatabaseView.tsx
+++ b/extensions/notion/src/components/DatabaseView.tsx
@@ -1,5 +1,6 @@
 import { List, Image } from "@raycast/api";
 
+import { useKanbanViewConfig } from "../hooks";
 import { notionColorToTintColor, isType, Page, DatabaseProperty, PropertyConfig, User } from "../utils/notion";
 import type { DatabaseView } from "../utils/types";
 
@@ -32,11 +33,17 @@ export function DatabaseView(props: DatabaseViewProps) {
     users,
   } = props;
 
-  const viewType = databaseView?.type ?? "list";
-  const propertyId = databaseView?.kanban?.property_id;
-  const statusProperty = databaseProperties.find((dp) => dp.id === propertyId);
+  const { kanbanConfig } = useKanbanViewConfig(databaseId);
+  const statusProperty = kanbanConfig?.property_id
+    ? databaseProperties.find((dp) => dp.id === kanbanConfig?.property_id)
+    : undefined;
 
-  if (viewType === "list" || !propertyId || !statusProperty || !isType(statusProperty, "status", "select")) {
+  if (
+    !kanbanConfig?.active ||
+    !kanbanConfig.property_id ||
+    !statusProperty ||
+    !isType(statusProperty, "status", "select")
+  ) {
     return (
       <>
         {databasePages?.map((p) => (
@@ -62,7 +69,7 @@ export function DatabaseView(props: DatabaseViewProps) {
     started_ids: startedIds = [],
     completed_ids: completedIds = [],
     canceled_ids: canceledIds = [],
-  } = databaseView?.kanban || {};
+  } = kanbanConfig || {};
 
   // Section Order: Started > Not Started > Completed > Canceled > Backlog | Other (hidden)
   const sectionIds = startedIds.concat(notStartedIds).concat(completedIds).concat(canceledIds).concat(backlogIds);
@@ -107,7 +114,7 @@ export function DatabaseView(props: DatabaseViewProps) {
   const tempSections: Record<string, Page[]> = {};
 
   databasePages.forEach((p) => {
-    const prop = Object.values(p.properties).find((x) => x.id === propertyId);
+    const prop = Object.values(p.properties).find((x) => x.id === kanbanConfig.property_id);
     let propId = "_select_null_";
 
     if (prop && (prop.type == "select" || prop.type == "status") && prop.value) propId = prop.value.id;
@@ -178,13 +185,14 @@ export function DatabaseView(props: DatabaseViewProps) {
                 databaseProperty={statusProperty}
                 options={customOptions}
                 pageId={p.id}
-                pageProperty={p.properties[propertyId]}
+                pageProperty={p.properties[kanbanConfig.property_id]}
                 icon="./icon/kanban_status_started.png"
                 shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
                 mutate={mutate}
               />,
             ]}
             databaseView={databaseView}
+            isKanban={kanbanConfig.active}
             databaseProperties={databaseProperties}
             setDatabaseView={setDatabaseView}
             mutate={mutate}

--- a/extensions/notion/src/components/PageListItem.tsx
+++ b/extensions/notion/src/components/PageListItem.tsx
@@ -42,6 +42,7 @@ type PageListItemProps = {
   users?: User[];
   icon?: Image.ImageLike;
   customActions?: JSX.Element[];
+  isKanban?: boolean;
 };
 
 export function PageListItem({
@@ -55,6 +56,7 @@ export function PageListItem({
   icon = getPageIcon(page),
   users,
   mutate,
+  isKanban,
 }: PageListItemProps) {
   const accessories: List.Item.Accessory[] = [];
 
@@ -221,22 +223,16 @@ export function PageListItem({
             />
           </ActionPanel.Section>
 
-          {databaseProperties && setDatabaseView ? (
-            <ActionPanel.Section title="View options">
-              {page.parent_database_id ? (
-                <Action.Push
-                  title="Set View Type"
-                  icon={databaseView?.type ? `./icon/view_${databaseView.type}.png` : "./icon/view_list.png"}
-                  shortcut={{ modifiers: ["cmd", "opt", "shift"], key: "v" }}
-                  target={
-                    <DatabaseViewForm
-                      databaseId={page.parent_database_id}
-                      databaseView={databaseView}
-                      setDatabaseView={setDatabaseView}
-                    />
-                  }
-                />
-              ) : null}
+          <ActionPanel.Section title="View options">
+            {page.parent_database_id && (
+              <Action.Push
+                title="Set View Type"
+                icon={isKanban ? `./icon/view_kanban.png` : "./icon/view_list.png"}
+                shortcut={{ modifiers: ["cmd", "opt", "shift"], key: "v" }}
+                target={<DatabaseViewForm databaseId={page.parent_database_id} />}
+              />
+            )}
+            {databaseProperties && setDatabaseView ? (
               <ActionSetVisibleProperties
                 databaseProperties={databaseProperties}
                 selectedPropertiesIds={visiblePropertiesIds}
@@ -256,8 +252,8 @@ export function PageListItem({
                   });
                 }}
               />
-            </ActionPanel.Section>
-          ) : null}
+            ) : null}
+          </ActionPanel.Section>
 
           {page.url ? (
             <ActionPanel.Section>

--- a/extensions/notion/src/components/actions/ActionSetVisibleProperties.tsx
+++ b/extensions/notion/src/components/actions/ActionSetVisibleProperties.tsx
@@ -7,8 +7,9 @@ export function ActionSetVisibleProperties(props: {
   selectedPropertiesIds?: string[];
   onSelect: (propertyId: string) => void;
   onUnselect: (propertyId: string) => void;
+  hideTitle?: boolean;
 }) {
-  const { databaseProperties, onSelect, onUnselect, selectedPropertiesIds = [] } = props;
+  const { databaseProperties, selectedPropertiesIds = [], onSelect, onUnselect, hideTitle } = props;
 
   const selectedProperties = selectedPropertiesIds.map((id) => databaseProperties.find((dp) => dp.id === id));
   const unselectedProperties = databaseProperties.filter((dp) => !selectedPropertiesIds.includes(dp.id));
@@ -20,20 +21,21 @@ export function ActionSetVisibleProperties(props: {
       shortcut={{ modifiers: ["cmd", "opt", "shift"], key: "p" }}
     >
       <ActionPanel.Section>
-        {selectedProperties.map(
-          (property) =>
-            property && (
-              <Action
-                key={`selected-property-${property.id}`}
-                icon={getPropertyIcon(property)}
-                title={`${property.name}  ✓`}
-                onAction={() => onUnselect(property.id)}
-              />
-            ),
-        )}
+        {selectedProperties.map((property) => {
+          if (!property || (hideTitle && property.type == "title")) return null;
+          return (
+            <Action
+              key={`selected-property-${property.id}`}
+              icon={getPropertyIcon(property)}
+              title={`${property.name}  ✓`}
+              onAction={() => onUnselect(property.id)}
+            />
+          );
+        })}
       </ActionPanel.Section>
       <ActionPanel.Section>
         {unselectedProperties.map((dp) => {
+          if (hideTitle && dp.type == "title") return null;
           return (
             <Action
               key={`unselected-property-${dp.id}`}

--- a/extensions/notion/src/components/forms/CreatePageForm.tsx
+++ b/extensions/notion/src/components/forms/CreatePageForm.tsx
@@ -22,6 +22,7 @@ import {
   useRecentPages,
   useRelations,
   useUsers,
+  useConvertDepreciatedViewConfig,
 } from "../../hooks";
 import { createDatabasePage, DatabaseProperty } from "../../utils/notion";
 import { handleOnOpenPage } from "../../utils/openPage";
@@ -60,6 +61,8 @@ const NON_EDITABLE_PROPETY_TYPES = ["formula"];
 const filterNoEditableProperties = (dp: DatabaseProperty) => !NON_EDITABLE_PROPETY_TYPES.includes(dp.type);
 
 export function CreatePageForm({ mutate, launchContext, defaults }: CreatePageFormProps) {
+  useConvertDepreciatedViewConfig();
+
   const preferences = getPreferenceValues<CreatePageFormPreferences>();
   const defaultValues = launchContext?.defaults ?? defaults;
   const initialDatabaseId = defaultValues?.database;

--- a/extensions/notion/src/components/forms/CreatePageForm.tsx
+++ b/extensions/notion/src/components/forms/CreatePageForm.tsx
@@ -69,8 +69,9 @@ export function CreatePageForm({ mutate, launchContext, defaults }: CreatePageFo
 
   const [databaseId, setDatabaseId] = useState<string | null>(initialDatabaseId ? initialDatabaseId : null);
   const { data: databaseProperties } = useDatabaseProperties(databaseId, filterNoEditableProperties);
-  const { visiblePropIds, setVisiblePropIds } = useVisibleDatabasePropIds(
-    databaseId || "__no_id__",
+  const { visiblePropIds, setVisiblePropIds } = useVisiblePropIds(
+    databaseId,
+    databaseProperties,
     launchContext?.visiblePropIds,
   );
   const { data: users } = useUsers();
@@ -301,4 +302,21 @@ Please note that HTML tags and thematic breaks are not supported in Notion due t
       />
     </Form>
   );
+}
+
+function useVisiblePropIds(
+  databaseId: string | null,
+  databaseProperties: DatabaseProperty[],
+  quicklinkProps?: string[],
+): ReturnType<typeof useVisibleDatabasePropIds> {
+  if (quicklinkProps) {
+    const [visiblePropIds, setVisiblePropIds] = useState<string[]>(quicklinkProps);
+    return { visiblePropIds, setVisiblePropIds };
+  } else {
+    return useVisibleDatabasePropIds(
+      "form",
+      databaseId ?? "__no_id__",
+      databaseProperties.map((dp) => dp.id),
+    );
+  }
 }

--- a/extensions/notion/src/components/forms/DatabaseViewForm.tsx
+++ b/extensions/notion/src/components/forms/DatabaseViewForm.tsx
@@ -1,46 +1,33 @@
 import { Form, ActionPanel, Icon, showToast, useNavigation, Action, Toast } from "@raycast/api";
 import { useEffect, useState } from "react";
 
-import { useDatabaseProperties, useDatabases } from "../../hooks";
+import { useDatabaseProperties, useDatabases, useKanbanViewConfig, KanbanConfig } from "../../hooks";
 import { notionColorToTintColor, DatabaseProperty, isType } from "../../utils/notion";
-import { DatabaseView } from "../../utils/types";
 
-export function DatabaseViewForm(props: {
-  databaseId: string;
-  databaseView?: DatabaseView;
-  setDatabaseView: (databaseView: DatabaseView) => Promise<void>;
-}) {
-  const { databaseId: presetDatabaseId, databaseView, setDatabaseView } = props;
-
+export function DatabaseViewForm({ databaseId: presetDatabaseId }: { databaseId: string }) {
   const { pop } = useNavigation();
 
   async function handleSubmit(values: Form.Values) {
-    const newDatabaseView = {
-      properties: databaseView?.properties ? databaseView.properties : {},
-      sort_by: databaseView?.sort_by ? databaseView.sort_by : {},
-      type: values.type ? values.type : "list",
-    } as DatabaseView;
-
-    if (values.type === "kanban") {
-      newDatabaseView.kanban = {
+    if (kanbanConfig && values["type"] == "list") setKanbanConfig({ ...kanbanConfig, active: false });
+    else {
+      setKanbanConfig({
+        active: true,
         property_id: values["kanban::property_id"],
         backlog_ids: values["kanban::backlog_ids"] ? values["kanban::backlog_ids"] : [],
         not_started_ids: values["kanban::not_started_ids"] ? values["kanban::not_started_ids"] : [],
         started_ids: values["kanban::started_ids"] ? values["kanban::started_ids"] : [],
         completed_ids: values["kanban::completed_ids"] ? values["kanban::completed_ids"] : [],
         canceled_ids: values["kanban::canceled_ids"] ? values["kanban::canceled_ids"] : [],
-      };
+      });
     }
-
-    setDatabaseView(newDatabaseView);
-
     pop();
   }
 
   const { data: databases, isLoading: isLoadingDatabases } = useDatabases();
   const [databaseId, setDatabaseId] = useState(presetDatabaseId);
-  const [viewType, setViewType] = useState<"kanban" | "list">(databaseView?.type ? databaseView.type : "list");
   const { data: databaseProperties, isLoading: isLoadingDatabaseProperties } = useDatabaseProperties(databaseId);
+  const { kanbanConfig, setKanbanConfig } = useKanbanViewConfig(databaseId);
+  const [viewType, setViewType] = useState<"kanban" | "list">(kanbanConfig?.active ? "kanban" : "list");
 
   useEffect(() => {
     if (databaseProperties && viewType === "kanban") {
@@ -106,7 +93,7 @@ export function DatabaseViewForm(props: {
       <Form.Separator />
       {databaseProperties && viewType === "kanban" ? (
         <KanbanViewFormItem
-          databaseView={databaseView}
+          kanbanConfig={kanbanConfig}
           properties={databaseProperties.filter((dp): dp is StatusDatabaseProperty => isType(dp, "select", "status"))}
         />
       ) : null}
@@ -125,19 +112,19 @@ const statusTypes: { [key: string]: string } = {
 type StatusDatabaseProperty = Extract<DatabaseProperty, { type: "select" | "status" }>;
 interface KanbanViewFormItemParams {
   properties: StatusDatabaseProperty[];
-  databaseView?: DatabaseView;
+  kanbanConfig: KanbanConfig | undefined;
 }
-function KanbanViewFormItem({ properties, databaseView }: KanbanViewFormItemParams) {
+function KanbanViewFormItem({ properties, kanbanConfig }: KanbanViewFormItemParams) {
   const [statusPropertyId, setStatusPropertyId] = useState<string | undefined>(
-    databaseView?.kanban?.property_id ? databaseView?.kanban?.property_id : properties[0]?.id,
+    kanbanConfig?.property_id ? kanbanConfig?.property_id : properties[0]?.id,
   );
 
   const statusProperty = properties.find((dp) => dp.id === statusPropertyId);
 
-  function getStatusState(property: DatabaseProperty | undefined) {
-    if (!property || !isType(property, "status")) return;
+  function getStatusState(property: StatusDatabaseProperty | undefined) {
+    if (!property) return;
     const statusOptions = property.config.options.filter((o) => o.id !== "_select_null_");
-    const currentConfig = databaseView?.kanban;
+    const currentConfig = kanbanConfig;
 
     const defaultBacklogOpts = currentConfig ? currentConfig.backlog_ids : ["_select_null_"];
     const defaultCompletedOpts = currentConfig

--- a/extensions/notion/src/components/forms/DatabaseViewForm.tsx
+++ b/extensions/notion/src/components/forms/DatabaseViewForm.tsx
@@ -19,7 +19,6 @@ export function DatabaseViewForm(props: {
       properties: databaseView?.properties ? databaseView.properties : {},
       sort_by: databaseView?.sort_by ? databaseView.sort_by : {},
       type: values.type ? values.type : "list",
-      name: values.name ? values.name : null,
     } as DatabaseView;
 
     if (values.type === "kanban") {

--- a/extensions/notion/src/hooks/index.ts
+++ b/extensions/notion/src/hooks/index.ts
@@ -16,6 +16,8 @@ import {
 } from "../utils/notion";
 import { DatabaseView } from "../utils/types";
 
+export * from "./view-config";
+
 export function useUsers() {
   const value = useCachedPromise(() => fetchUsers());
 

--- a/extensions/notion/src/hooks/index.ts
+++ b/extensions/notion/src/hooks/index.ts
@@ -1,6 +1,5 @@
-import { LocalStorage, showToast } from "@raycast/api";
+import { LocalStorage } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { useState } from "react";
 
 import {
   fetchDatabaseProperties,
@@ -14,7 +13,6 @@ import {
   type Page,
   type DatabaseProperty,
 } from "../utils/notion";
-import { DatabaseView } from "../utils/types";
 
 export * from "./view-config";
 
@@ -66,48 +64,6 @@ export function useDatabaseProperties(databaseId: string | null, filter?: (value
   );
 
   return { ...value, data: value.data ?? [] };
-}
-
-export function useVisibleDatabasePropIds(
-  databaseId: string,
-  quicklinkProps?: string[],
-): {
-  visiblePropIds?: string[];
-  isLoading: boolean;
-  setVisiblePropIds: (value: string[]) => Promise<void> | void;
-} {
-  if (quicklinkProps) {
-    const [visiblePropIds, setVisiblePropIds] = useState(quicklinkProps);
-    return { visiblePropIds, isLoading: false, setVisiblePropIds };
-  } else {
-    const { data, isLoading, setDatabaseView } = useDatabasesView(databaseId);
-    const setVisiblePropIds = (props?: string[]) => setDatabaseView({ ...data, create_properties: props });
-    return { visiblePropIds: data.create_properties, isLoading, setVisiblePropIds };
-  }
-}
-
-export function useDatabasesView(databaseId: string) {
-  const { data, isLoading, mutate } = useCachedPromise(async () => {
-    const data = await LocalStorage.getItem<string>("DATABASES_VIEWS");
-
-    if (!data) return {};
-
-    return JSON.parse(data) as { [databaseId: string]: DatabaseView | undefined };
-  });
-
-  async function setDatabaseView(view: DatabaseView) {
-    if (!data) return;
-
-    await LocalStorage.setItem("DATABASES_VIEWS", JSON.stringify({ ...data, [databaseId]: view }));
-    mutate();
-    showToast({ title: "View updated" });
-  }
-
-  return {
-    data: data?.[databaseId] || {},
-    isLoading,
-    setDatabaseView,
-  };
 }
 
 export class RecentPage {

--- a/extensions/notion/src/hooks/view-config.ts
+++ b/extensions/notion/src/hooks/view-config.ts
@@ -1,10 +1,10 @@
 import { LocalStorage, Cache, showToast, Toast } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
+import { useEffect } from "react";
+
 
 export function useKanbanViewConfig(databaseId: string) {
   const [kanbanConfig, setKanbanConfig] = useCachedState<KanbanConfig | undefined>(`kanban_config-${databaseId}`);
-  convertDepreciatedViewConfig();
-  // console.log(`Database(${databaseId}) config from cache:\n%O`, kanbanConfig);
   return { kanbanConfig, setKanbanConfig };
 }
 
@@ -16,6 +16,12 @@ export interface KanbanConfig {
   started_ids: string[];
   completed_ids: string[];
   canceled_ids: string[];
+}
+
+export function useConvertDepreciatedViewConfig() {
+  useEffect(() => {
+    convertDepreciatedViewConfig();
+  }, []);
 }
 
 /**
@@ -30,7 +36,7 @@ async function convertDepreciatedViewConfig() {
   const jsonString = await LocalStorage.getItem<string>("DATABASES_VIEWS");
   if (!jsonString) return;
 
-  cache.set("viewConfigMigrated", "in progress");
+  cache.set("viewConfigMigrationStatus", "in progress");
   const toast = await showToast({ title: "Migrating view configuration format", style: Toast.Style.Animated });
 
   const viewConfigs = JSON.parse(jsonString) as Record<string, Partial<DepreciatedDatabaseView>>;
@@ -53,7 +59,7 @@ async function convertDepreciatedViewConfig() {
   toast.title = "View configurations migrated";
   toast.style = Toast.Style.Success;
 
-  cache.set("viewConfigMigrated", "complete");
+  cache.set("viewConfigMigrationStatus", "complete");
 }
 
 export interface DepreciatedDatabaseView {

--- a/extensions/notion/src/hooks/view-config.ts
+++ b/extensions/notion/src/hooks/view-config.ts
@@ -2,6 +2,27 @@ import { LocalStorage, Cache, showToast, Toast } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { useEffect } from "react";
 
+export function useVisibleDatabasePropIds(
+  context: "list",
+  databaseId: string | undefined,
+): { visiblePropIds: string[]; setVisiblePropIds: (value: string[]) => void };
+export function useVisibleDatabasePropIds(
+  context: "form" | "page",
+  databaseId: string | undefined,
+  initialValue: string[],
+): { visiblePropIds: string[]; setVisiblePropIds: (value: string[]) => void };
+export function useVisibleDatabasePropIds(
+  context: "list" | "page" | "form",
+  databaseId: string | undefined,
+  initialValue: string[] = [],
+) {
+  const [visiblePropIds, setVisiblePropIds] = useCachedState<string[]>(
+    `visible_props-${databaseId ?? "no_database_id"}-${context}`,
+    initialValue,
+  );
+
+  return { visiblePropIds, setVisiblePropIds };
+}
 
 export function useKanbanViewConfig(databaseId: string) {
   const [kanbanConfig, setKanbanConfig] = useCachedState<KanbanConfig | undefined>(`kanban_config-${databaseId}`);

--- a/extensions/notion/src/hooks/view-config.ts
+++ b/extensions/notion/src/hooks/view-config.ts
@@ -1,0 +1,16 @@
+import { useCachedState } from "@raycast/utils";
+
+export function useKanbanViewConfig(databaseId: string) {
+  const [kanbanConfig, setKanbanConfig] = useCachedState<KanbanConfig | undefined>(`kanban_config-${databaseId}`);
+  return { kanbanConfig, setKanbanConfig };
+}
+
+export interface KanbanConfig {
+  active: boolean;
+  property_id: string;
+  backlog_ids: string[];
+  not_started_ids: string[];
+  started_ids: string[];
+  completed_ids: string[];
+  canceled_ids: string[];
+}

--- a/extensions/notion/src/hooks/view-config.ts
+++ b/extensions/notion/src/hooks/view-config.ts
@@ -1,6 +1,8 @@
-import { LocalStorage, Cache, showToast, Toast } from "@raycast/api";
+import { LocalStorage, Cache, showToast, Toast, open, popToRoot } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { useEffect } from "react";
+
+let key = "";
 
 export function useVisibleDatabasePropIds(
   context: "list",
@@ -20,6 +22,14 @@ export function useVisibleDatabasePropIds(
     `visible_props-${databaseId ?? "no_database_id"}-${context}`,
     initialValue,
   );
+
+  useEffect(() => {
+    const newKey = `visible_props-${databaseId ?? "no_database_id"}-${context}`;
+    if (newKey != key) {
+      console.log(`key: %s\nvalue: %O\n`, newKey, visiblePropIds);
+      key = newKey;
+    }
+  }, [databaseId, context, visiblePropIds]);
 
   return { visiblePropIds, setVisiblePropIds };
 }
@@ -60,35 +70,53 @@ async function convertDepreciatedViewConfig() {
   cache.set("viewConfigMigrationStatus", "in progress");
   const toast = await showToast({ title: "Migrating view configuration format", style: Toast.Style.Animated });
 
-  const viewConfigs = JSON.parse(jsonString) as Record<string, Partial<DepreciatedDatabaseView>>;
+  try {
+    const viewConfigs = JSON.parse(jsonString) as Record<string, Partial<DepreciatedDatabaseView>>;
 
-  for (const databaseId in viewConfigs) {
-    const { kanban } = viewConfigs[databaseId];
+    for (const databaseId in viewConfigs) {
+      const { properties, create_properties, kanban, type } = viewConfigs[databaseId];
+      if (properties) {
+        console.log(`properties key: %s\nvalue: %O\n`, `visible_props-${databaseId}-list`);
+        cache.set(`visible_props-${databaseId}-list`, JSON.stringify(Object.keys(properties)));
+      }
+      if (create_properties) {
+        console.log(`create_properties key: %s\nvalue: %O\n`, `visible_props-${databaseId}-form`);
+        cache.set(`visible_props-${databaseId}-form`, JSON.stringify(create_properties));
+      }
+      if (kanban)
+        cache.set(
+          `kanban_config-${databaseId}`,
+          JSON.stringify({
+            ...kanban,
+            active: type == "kanban",
+          } satisfies KanbanConfig),
+        );
+    }
 
-    if (kanban)
-      cache.set(
-        `kanban_config-${databaseId}`,
-        JSON.stringify({
-          ...kanban,
-          active: viewConfigs[databaseId].type == "kanban",
-        } satisfies KanbanConfig),
-      );
+    await LocalStorage.removeItem("DATABASES_VIEWS");
 
-    // TOOD: Handle the rest of viewConfigs
+    toast.title = "View configurations migrated";
+    toast.style = Toast.Style.Success;
+    cache.set("viewConfigMigrationStatus", "complete");
+    popToRoot(); // Don't love this, but it's the only way I can think to update state. It will only run once.
+  } catch (error) {
+    console.warn(error);
+    toast.title = "Migrated failed";
+    toast.message = "Please open an issue.\n" + String(error);
+    toast.primaryAction = {
+      title: "Open Issue",
+      onAction: () =>
+        open(
+          "https://github.com/raycast/extensions/issues/new?template=extension_bug_report.yml&title=%5BNotion%5D+Migration+of+view+configurations+failed&extension-url=https%3A%2F%2Fwww.raycast.com%2Fnotion%2Fnotion",
+        ),
+    };
   }
-
-  toast.title = "View configurations migrated";
-  toast.style = Toast.Style.Success;
-
-  cache.set("viewConfigMigrationStatus", "complete");
 }
 
 export interface DepreciatedDatabaseView {
-  // // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // properties?: Record<string, any>;
-  // create_properties?: string[];
-  // // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // sort_by?: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  properties?: Record<string, any>;
+  create_properties?: string[];
   type?: "kanban" | "list";
   kanban?: {
     property_id: string;

--- a/extensions/notion/src/search-page.tsx
+++ b/extensions/notion/src/search-page.tsx
@@ -3,13 +3,15 @@ import { useCachedPromise, withAccessToken } from "@raycast/utils";
 import { useState } from "react";
 
 import { PageListItem } from "./components";
-import { useRecentPages, useUsers } from "./hooks";
+import { useRecentPages, useUsers, useConvertDepreciatedViewConfig } from "./hooks";
 import { search } from "./utils/notion";
 import { notionService } from "./utils/notion/oauth";
 
 function Search() {
   const { data: recentPages, setRecentPage, removeRecentPage } = useRecentPages();
   const [searchText, setSearchText] = useState<string>("");
+
+  useConvertDepreciatedViewConfig();
 
   const { data, isLoading, pagination, mutate } = useCachedPromise(
     (searchText: string) =>

--- a/extensions/notion/src/search-page.tsx
+++ b/extensions/notion/src/search-page.tsx
@@ -18,6 +18,7 @@ function Search() {
         return { data: pages, hasMore, cursor: nextCursor };
       },
     [searchText],
+    { keepPreviousData: true },
   );
 
   const { data: users } = useUsers();

--- a/extensions/notion/src/utils/types.ts
+++ b/extensions/notion/src/utils/types.ts
@@ -5,7 +5,6 @@ export interface DatabaseView {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sort_by?: Record<string, any>;
   type?: "kanban" | "list";
-  name?: string | null;
   kanban?: KanbanView;
 }
 


### PR DESCRIPTION
## Description

Main change: View configuration data is now managed with `useCacheState` instead of `LocalStorage`. This get's rid of the following
- Prop drilling
- Storing unnecessary data
- Unnecessary state refreshes.

In addition, I've enabled `keepPreviousData` for `useCachedPromise` in the `search-page` command and the `DatabaseList` component.

## Migration

I've created a function to handle data migration. It will have practically no impact on performance, but I'd still recommend removing it after 6 months.